### PR TITLE
Avoid division by zero norm when computing Hamiltonian environments

### DIFF
--- a/src/infinitecmps/environments.jl
+++ b/src/infinitecmps/environments.jl
@@ -121,7 +121,8 @@ function leftenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HL₀=nothing;
         HL₀ = HL₀ - ρL * dot(HL₀, ρR)
     end
     let TL = LeftTransfer(Ψ)
-        HL, infoL = linsolve(hL / norm(hL), HL₀, linalg) do x
+        b = (norm(hL) ≈ 0.0) ? zero(hL) : hL / norm(hL)
+        HL, infoL = linsolve(b, HL₀, linalg) do x
             y = ∂(x) - TL(x; kwargs...)
             y = axpy!(dot(ρR, x), ρL, y)
             return truncate!(y; tol=linalg.tol / 100, kwargs...)

--- a/src/infinitecmps/environments.jl
+++ b/src/infinitecmps/environments.jl
@@ -129,7 +129,7 @@ function leftenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HL₀=nothing;
             y = axpy!(dot(ρR, x), ρL, y)
             return truncate!(y; tol=linalg.tol / 100, kwargs...)
         end
-        HL = rmul!(HL + HL', 0.5 * norm(hL))
+        HL = rmul!(HL + HL', (hLnorm < one(hLnorm)) ? 0.5 : 0.5 * norm(hL))
         # truncate!(HL; tol = linalg.tol/100, kwargs...)
         res = hL - (∂(HL) - TL(HL))
         infoL = ConvergenceInfo(infoL.converged, res, norm(res), infoL.numiter,
@@ -164,7 +164,7 @@ function rightenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HR₀=nothing;
             y = axpy!(dot(ρL, x), ρR, y)
             return truncate!(y; tol=linalg.tol / 100, kwargs...)
         end
-        HR = rmul!(HR + HR', 0.5 * norm(hR))
+        HR = rmul!(HR + HR', (hRnorm < one(hRnorm)) ? 0.5 : 0.5 * norm(hR))
         # res = hR - (-∂(HR)-TR(HR))
         # truncate!(HR; tol = linalg.tol/100, kwargs...)
         res = hR - (-∂(HR) - TR(HR))

--- a/src/infinitecmps/environments.jl
+++ b/src/infinitecmps/environments.jl
@@ -121,7 +121,7 @@ function leftenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HL₀=nothing;
         HL₀ = HL₀ - ρL * dot(HL₀, ρR)
     end
     let TL = LeftTransfer(Ψ)
-        b = (norm(hL) ≈ 0.0) ? zero(hL) : hL / norm(hL)
+        b = (norm(hL) < one(norm(hL))) ? hL : hL / norm(hL)
         HL, infoL = linsolve(b, HL₀, linalg) do x
             y = ∂(x) - TL(x; kwargs...)
             y = axpy!(dot(ρR, x), ρL, y)
@@ -154,7 +154,7 @@ function rightenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HR₀=nothing;
         HR₀ = HR₀ - ρR * dot(ρL, HR₀)
     end
     let TR = RightTransfer(Ψ)
-        b = (norm(hR) ≈ 0.0) ? zero(hR) : hR / norm(hR)
+        b = (norm(hR) < one(norm(hR))) ? hR : hR / norm(hR)
         HR, infoR = linsolve(b, HR₀, linalg) do x
             y = -∂(x) - TR(x; kwargs...)
             y = axpy!(dot(ρL, x), ρR, y)

--- a/src/infinitecmps/environments.jl
+++ b/src/infinitecmps/environments.jl
@@ -121,7 +121,9 @@ function leftenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HL₀=nothing;
         HL₀ = HL₀ - ρL * dot(HL₀, ρR)
     end
     let TL = LeftTransfer(Ψ)
-        b = (norm(hL) < one(norm(hL))) ? hL : hL / norm(hL)
+        hLnorm = norm(hL)
+        # rescale to avoid issues with truncate! and linsolve convergence
+        b = (hLnorm < one(hLnorm)) ? hL : hL / hLnorm
         HL, infoL = linsolve(b, HL₀, linalg) do x
             y = ∂(x) - TL(x; kwargs...)
             y = axpy!(dot(ρR, x), ρL, y)
@@ -154,7 +156,9 @@ function rightenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HR₀=nothing;
         HR₀ = HR₀ - ρR * dot(ρL, HR₀)
     end
     let TR = RightTransfer(Ψ)
-        b = (norm(hR) < one(norm(hR))) ? hR : hR / norm(hR)
+        hRnorm = norm(hR)
+        # rescale to avoid issues with truncate! and linsolve convergence
+        b = (hRnorm < one(hRnorm)) ? hR : hR / hRnorm
         HR, infoR = linsolve(b, HR₀, linalg) do x
             y = -∂(x) - TR(x; kwargs...)
             y = axpy!(dot(ρL, x), ρR, y)

--- a/src/infinitecmps/environments.jl
+++ b/src/infinitecmps/environments.jl
@@ -154,7 +154,8 @@ function rightenv(H::LocalHamiltonian, Ψρs::InfiniteCMPSData, HR₀=nothing;
         HR₀ = HR₀ - ρR * dot(ρL, HR₀)
     end
     let TR = RightTransfer(Ψ)
-        HR, infoR = linsolve(hR / norm(hR), HR₀, linalg) do x
+        b = (norm(hR) ≈ 0.0) ? zero(hR) : hR / norm(hR)
+        HR, infoR = linsolve(b, HR₀, linalg) do x
             y = -∂(x) - TR(x; kwargs...)
             y = axpy!(dot(ρL, x), ρR, y)
             return truncate!(y; tol=linalg.tol / 100, kwargs...)


### PR DESCRIPTION
Closes #8 . For D=1, the left and right Hamiltonian environment initializes to 0, which resulted in NaNs propagating through the rest of the ground state and excitation ansatz computations.